### PR TITLE
made vncpasswd itempotent and only restart server if something changed

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,8 @@
----
 # handlers file for tigervnc-server
+---
+- name: restart vncserver
+  service:
+    name: vncserver
+    state: restarted
+  tags:
+    - tigervnc-server

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,55 +2,9 @@ galaxy_info:
   author: Jan Stavel @ Red Hat
   description: An ansible role to install TigerVNC server
   company: Red Hat
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
   license: license (GPLv2, CC-BY, etc)
-
   min_ansible_version: 1.2
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
-  #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags: ['vnc']
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
 
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,9 @@
   package:
     name: tigervnc-server
     state: present
+  notify: restart vncserver
+  tags:
+    - tigervnc-server
 
 - name: copy vnc server config
   template:
@@ -12,6 +15,9 @@
     owner: root
     group: root
     mode: 0644
+  notify: restart vncserver
+  tags:
+    - tigervnc-server
 
 - name: prepare a file .vnc/passwd
   file:
@@ -20,18 +26,36 @@
     group: "{{ VNC_USER }}"
     mode: 0600
     state: touch
+  notify: restart vncserver
+  tags:
+    - tigervnc-server
+
+- name: check for vncpassword
+  stat:
+    path: "~{{ VNC_USER }}/.vnc/passwd"
+  register: vnc_passwd_file
+  tags:
+    - tigervnc-server
+
+- name: determine if vnc password changes
+  shell: "[[ $(echo -n {{ VNC_PASSWORD }} | vncpasswd -f | md5sum | cut -d ' ' -f1) == $(md5sum ~{{ VNC_USER }}/.vnc/passwd | cut -d ' ' -f1)]]"
+  register: vncpasswd_changed
+  when: vnc_passwd_file.exists == False
+  tags:
+    - tigervnc-server
 
 - name: set password for vnc user
   shell: "echo -n {{ VNC_PASSWORD }} | vncpasswd -f > ~{{ VNC_USER }}/.vnc/passwd"
   become: yes
   become_user: "{{ VNC_USER }}"
+  when: (vnc_passwd_file.exists == False) or (vncpasswd_changed.rc == 1)
+  notify: restart vncserver
+  tags:
+    - tigervnc-server
 
 - name: enable vncserver service
   service:
     name: vncserver
     enabled: yes
-
-- name: restart vncserver service
-  service:
-    name: vncserver
-    state: restarted
+  tags:
+    - tigervnc-server


### PR DESCRIPTION
This PR does a couple of things:

- adds tags so the role can be debuged as part of a larger playbook
- only restarts the vnc server if something has changed
- only overwrites the vnc password if the password has changed.
- removed ansible galaxy templating comments 